### PR TITLE
Updates to correct warnings, repair a protocol error, and fix a redundant empty "M" report in status

### DIFF
--- a/inc/config.h
+++ b/inc/config.h
@@ -40,8 +40,12 @@
 //#define DEFAULT_CNC3020
 
 #define SG
-#define STM32F103C8
-#define USEUSB
+#ifndef STM32F103C8
+	#define STM32F103C8
+#endif
+#ifndef USEUSB
+	#define USEUSB
+#endif
 
 #define CPU_MAP_STM32F103 // CPU_MAP_STM32F103
 #ifdef WIN32

--- a/src/main.c
+++ b/src/main.c
@@ -44,16 +44,18 @@ volatile uint8_t sys_rt_exec_debug;
 
 #if defined (STM32F103C8)
 #include "usb_lib.h"
+
 #ifdef USEUSB
-#include "usb_desc.h"
-#endif
 #include "hw_config.h"
-#ifdef USEUSB
+#include "usb_desc.h"
 #include "usb_pwr.h"
+#include "usb_prop.h"
 #endif
+
 #include "stm32eeprom.h"
 //#ifndef USEUSB
 #include "stm32f10x_usart.h"
+
 void USART1_Configuration(u32 BaudRate)
 {
 	GPIO_InitTypeDef GPIO_InitStructure;
@@ -90,7 +92,7 @@ void USART1_Configuration(u32 BaudRate)
 #endif
 
 //#endif
-
+void LedBlink(void);
 
 #ifdef WIN32
 int main(int argc, char *argv[])
@@ -120,7 +122,10 @@ int main(void)
 
     //RCC_SYSCLKConfig(RCC_SYSCLKSource_PLLCLK);//paul
 
-#define LEDBLINK
+#ifndef LEDBLINK
+    #define LEDBLINK
+#endif
+
 #ifdef LEDBLINK
 	GPIO_InitTypeDef GPIO_InitStructure;
 
@@ -243,7 +248,7 @@ int main(void)
      *
      */
     if (GPIO_ReadInputDataBit(SERIALSWITCH_PORT, SERIALSWITCH_BIT) == 1){ //if the jumper is bridged->USB
-		while (Virtual_Com_port_IsHostPortOpen() == false){
+		while (Virtual_Com_Port_IsHostPortOpen() == false){
 			delay_ms(1500);
 			LedBlink();
 			}
@@ -286,19 +291,19 @@ void _delay_ms(uint32_t x)
 
 
 
-void LedBlink()
+void LedBlink(void)
 {
 	static BitAction nOnFlag = Bit_SET;
 	GPIO_WriteBit(GPIOC, GPIO_Pin_13, nOnFlag); // C13 is connected to led which flashes to demonstrate the program is running
 	nOnFlag = (nOnFlag == Bit_SET) ? Bit_RESET : Bit_SET;
 }
-void myputchar(unsigned char c)
-{
-uart_putc(c, USART1);
-}
-unsigned char mygetchar()
-{
-return uart_getc(USART1);
-}
+//void myputchar(unsigned char c)
+//{
+//uart_putc(c, USART1);
+//}
+//unsigned char mygetchar()
+//{
+//return uart_getc(USART1);
+//}
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -93,6 +93,8 @@ void USART1_Configuration(u32 BaudRate)
 
 //#endif
 void LedBlink(void);
+void LED_TRACE(char count, int delay);
+
 
 #ifdef WIN32
 int main(int argc, char *argv[])
@@ -144,8 +146,14 @@ int main(void)
 //#else
 	Set_USBClock();
 	USB_Interrupts_Config();
+
+	LED_Trace(2,1500); // TODO: mikep 12/15/19 working debug of USB_Init() failure
+
 	USB_Init();
-//#endif
+
+	LED_Trace(4,500); // TODO: mikep 12/15/19 working debug of USB_Init() failure
+
+	//#endif
 
 #ifndef NOEEPROMSUPPORT
 	FLASH_Unlock();
@@ -296,6 +304,16 @@ void LedBlink(void)
 	static BitAction nOnFlag = Bit_SET;
 	GPIO_WriteBit(GPIOC, GPIO_Pin_13, nOnFlag); // C13 is connected to led which flashes to demonstrate the program is running
 	nOnFlag = (nOnFlag == Bit_SET) ? Bit_RESET : Bit_SET;
+}
+
+void LED_TRACE(char count, int delay)
+{
+	char x;
+	for (x=0;x<count;x++)
+	{
+		LedBlink();
+		ms_delay(delay);
+	}
 }
 //void myputchar(unsigned char c)
 //{

--- a/src/main.c
+++ b/src/main.c
@@ -147,11 +147,11 @@ int main(void)
 	Set_USBClock();
 	USB_Interrupts_Config();
 
-	LED_Trace(2,1500); // TODO: mikep 12/15/19 working debug of USB_Init() failure
+	LED_TRACE(2,1500); // TODO: mikep 12/15/19 working debug of USB_Init() failure
 
 	USB_Init();
 
-	LED_Trace(4,500); // TODO: mikep 12/15/19 working debug of USB_Init() failure
+	LED_TRACE(4,500); // TODO: mikep 12/15/19 working debug of USB_Init() failure
 
 	//#endif
 
@@ -312,7 +312,7 @@ void LED_TRACE(char count, int delay)
 	for (x=0;x<count;x++)
 	{
 		LedBlink();
-		ms_delay(delay);
+		delay_ms(delay);
 	}
 }
 //void myputchar(unsigned char c)

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -98,7 +98,7 @@ void protocol_main_loop()
           report_status_message(STATUS_OVERFLOW);
         } else if (line[0] == 0) {
           // Empty or comment line. For syncing purposes.
-          //report_status_message(STATUS_OK);//Paul, 13/01/19 no need to ouput Ok
+          report_status_message(STATUS_OK);
         } else if (line[0] == '$') {
           // Grbl '$' system command
           report_status_message(system_execute_line(line));

--- a/src/report.c
+++ b/src/report.c
@@ -397,14 +397,12 @@ void report_gcode_modes()
   /*
    * Author Paul, M6 state added
    */
-  report_util_gcode_modes_M();
     if (gc_state.modal.tool_enable) { // Note: Multiple tool states may be active at the same time.
       if (gc_state.modal.tool_enable) { report_util_gcode_modes_M(); serial_write('6'); }
     }
 	/*
 	 *  End
 	 */
-  report_util_gcode_modes_M();
   #ifdef ENABLE_M7
     if (gc_state.modal.coolant) { // Note: Multiple coolant states may be active at the same time.
       if (gc_state.modal.coolant & PL_COND_FLAG_COOLANT_MIST) { report_util_gcode_modes_M(); serial_write('7'); }

--- a/src/serial.c
+++ b/src/serial.c
@@ -49,7 +49,9 @@ uint8_t serial_tx_buffer[TX_RING_BUFFER];
 uint8_t serial_tx_buffer_head = 0;
 volatile uint8_t serial_tx_buffer_tail = 0;
 
-set_init_msg_report()
+void do_report_init_message(void);
+
+void set_init_msg_report(void)
 {
 	do_report_init_message();
 }

--- a/src/serial.c
+++ b/src/serial.c
@@ -53,7 +53,7 @@ void do_report_init_message(void);
 
 void set_init_msg_report(void)
 {
-	do_report_init_message();
+	report_init_message();
 }
 
 // Returns the number of bytes available in the RX serial buffer.

--- a/src/stepper.c
+++ b/src/stepper.c
@@ -442,7 +442,7 @@ void Timer1Proc()
   // Set the direction pins a couple of nanoseconds before we step the steppers
   DIRECTION_PORT = (DIRECTION_PORT & ~DIRECTION_MASK) | (st.dir_outbits & DIRECTION_MASK);
 #endif
-#ifdef STM32F103C8;
+#ifdef STM32F103C8
 	//GPIO_WriteBit(ISR_PORT, ISR_BIT, Bit_SET); //start isr measure time
   //LedBlink(); // Paul, enter the isr for oscilloscope
   GPIO_Write(DIRECTION_PORT, (GPIO_ReadOutputData(DIRECTION_PORT) & ~DIRECTION_MASK) | (st.dir_outbits & DIRECTION_MASK));

--- a/usb/usb_prop.c
+++ b/usb/usb_prop.c
@@ -259,7 +259,7 @@ void Virtual_Com_Port_Status_Out(void)
 
 #include <stbool.h>
 static bool host_port_open = false;
-bool Virtual_Com_port_IsHostPortOpen()
+bool Virtual_Com_Port_IsHostPortOpen(void)
 {
 	return bDeviceState == CONFIGURED && host_port_open;
 }

--- a/usb/usb_prop.h
+++ b/usb/usb_prop.h
@@ -64,6 +64,8 @@ RESULT Virtual_Com_Port_Get_Interface_Setting(uint8_t Interface, uint8_t Alterna
 uint8_t *Virtual_Com_Port_GetDeviceDescriptor(uint16_t );
 uint8_t *Virtual_Com_Port_GetConfigDescriptor(uint16_t);
 uint8_t *Virtual_Com_Port_GetStringDescriptor(uint16_t);
+bool Virtual_Com_Port_IsHostPortOpen(void);
+
 
 uint8_t *Virtual_Com_Port_GetLineCoding(uint16_t Length);
 uint8_t *Virtual_Com_Port_SetLineCoding(uint16_t Length);


### PR DESCRIPTION
This commit includes:
A number of warning repairs - consolidated definitions mostly, creation of formal declarations rather than implied ones. repaired 100+ warnings in a full build.  Need to disable some tool changer code that didn't look complete, and had some redefinitions of constants
Added a "TRACER" function to blink the led a specific number of times for debug purposes
Fix a capitalization issue in usb_prop
Put the "ok" back in after a status report
Fixed the logic issues causing there to be multiple "M" reports in the status report that had no numbers after them.
