### PR TITLE
Remove status_report on planner ring at BLOCK_BUFFER_SIZE-3

### DIFF
--- a/src/planner.c
+++ b/src/planner.c
@@ -44,7 +44,6 @@ static planner_t pl;
 uint8_t plan_next_block_index(uint8_t block_index)
 {
   block_index++;
-  if (block_index >= BLOCK_BUFFER_SIZE-3){report_realtime_status();}
   if (block_index == BLOCK_BUFFER_SIZE) { block_index = 0;}
   return(block_index);
 }
@@ -393,7 +392,7 @@ uint8_t plan_buffer_line(float *target, plan_line_data_t *pl_data)
 
   // Store programmed rate.
   if (block->condition & PL_COND_FLAG_RAPID_MOTION) { block->programmed_rate = block->rapid_rate; }
-  else { 
+  else {
     block->programmed_rate = pl_data->feed_rate;
     if (block->condition & PL_COND_FLAG_INVERSE_TIME) { block->programmed_rate *= block->millimeters; }
   }


### PR DESCRIPTION
Removed this extra realtime status report when getting the next planner block = BLOCK_BUFFER_SIZE-3.  This breaks some senders, including lightburn.